### PR TITLE
Add support Google Voice app

### DIFF
--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -23,7 +23,9 @@ class ListViewManager {
 
 			if (message.from === 'popup' && message.type === 'CHECK_GOOGLE_VOICE_SUPPORT') {
 				var url = window.location.href;
-				response(url.startsWith('https://hangouts.google.com/') || url.startsWith('https://inbox.google.com/'));
+				response(url.startsWith('https://hangouts.google.com/')
+					|| url.startsWith('https://inbox.google.com/')
+					|| url.startsWith('https://voice.google.com/'));
 			}
 
 			if (message.type === 'THREAD_VIEW_READY') {
@@ -33,6 +35,43 @@ class ListViewManager {
 				that.sendFromQueue();
 			}
 		});
+	}
+
+	sendGoogleVoiceSiteMessages() {
+		// switch To Text View
+		document.querySelector('div[aria-label^="Message"][role="tab"]').click();
+		// start search
+		document.querySelector('div[gv-id="send-new-message"]').click();
+		// populate search
+		let numInput = document.querySelector('gv-recipient-picker input[placeholder="Type a name or phone number"]');
+		numInput.value = '123456789';
+
+		// this fires the necessary events for Google Voice to pick up
+		setTimeout(function() {
+			numInput.focus();
+			numInput.select();
+			document.execCommand('cut');
+			document.execCommand('paste');
+		}, 10);
+
+		// select recipient
+		document.querySelector('gv-contact-list div[ng-class="::ctrl.Css.SEARCH_LIST"] div[ng-class="[\'md-body-1\', ctrl.Css.SEND_TO_PHONE_NUMBER]"]').click();
+
+		// populate message
+		let textInput = document.querySelector('textarea[aria-label="Type a message"]');
+		textInput.value = 'Hello world';
+
+		// this fires the necessary events for Google Voice to pick up
+		setTimeout(function() {
+			textInput.focus();
+			textInput.select();
+			document.execCommand('cut');
+			document.execCommand('paste');
+		}, 10);
+
+
+		// send
+		// document.querySelector('gv-icon-button[icon-name="send"] button[aria-label="Send message"]').click();
 	}
 
 	addMessagesToQueue(messages) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,7 +7,7 @@
 
   "description": "Send personalized bulk SMS messages via Google Voice from Google Inbox or Hangouts.",
 
-  "version": "0.1.4",
+  "version": "0.2.0",
 
   "background": {
     "scripts": ["background.js"]
@@ -21,7 +21,7 @@
 
   "content_scripts": [
     {
-      "matches": ["https://hangouts.google.com/webchat/*"],
+      "matches": ["https://hangouts.google.com/webchat/*", "https://voice.google.com/*"],
       "js": ["contentScript.js" ],
       "all_frames": true
     }

--- a/src/popup.html
+++ b/src/popup.html
@@ -79,21 +79,28 @@
 				</div>
 			</div>
 			<div class="input-group">
-				<button class="btn btn-success" id="send-messages-button" title="This will not send messages - it will just get them ready.">Prepare Messages</button>
+				<button class="btn btn-success" id="send-messages-button" title="This will not send messages - it will just get them ready.">Send Messages</button>
 			</div>
 		</div>
 		<div id="wrong-page-message" style="display: none;">
 			<div class="tip">
-				Unable to find Hangouts on the page.
+				Unable to find Google Voice on the page.
 			</div>
 			<div class="tip">
 				Try some of the following options:
 				<ul>
-					<li>Make sure you are currently on <a href="https://inbox.google.com" target="_blank">Google Inbox</a>
-				or <a href="https://hangouts.google.com" target="_blank">Google Hangouts</a></li>
-					<li>Make sure the Hangouts interface is on the page and finished loading</li>
+					<li>Make sure you are currently on
+						<a href="https://voice.google.com/messages" target="_blank">Google Voice</a>,
+						<a href="https://inbox.google.com" target="_blank">Google Inbox</a>,
+						or <a href="https://hangouts.google.com" target="_blank">Google Hangouts</a></li>
+					<li>
+						If you are using Google Voice via Hangouts:
+						<ul>
+							<li>Make sure the Hangouts interface is on the page and finished loading</li>
+							<li>Make sure Google Voice via Hangouts is enabled (<a href="https://support.google.com/voice/answer/6023920?co=GENIE.Platform%3DDesktop&hl=en" target="_blank">instructions</a>)</li>
+						</ul>
+					</li>
 					<li>Try refreshing the page</li>
-					<li>Make sure Google Voice via Hangouts is enabled (<a href="https://support.google.com/voice/answer/6023920?co=GENIE.Platform%3DDesktop&hl=en" target="_blank">instructions</a>)</li>
 					<li>If it still isn't working for you, please report the issue <a href="https://github.com/brismuth/google-voice-bulk-texter/issues/new" target="_blank">here</a></li>
 				</ul>
 			</div>

--- a/src/popup.js
+++ b/src/popup.js
@@ -90,6 +90,7 @@ function addUIListeners() {
 	var message = document.getElementById('message');
 
 	sendMessagesButton.addEventListener('click', () => {
+		sendMessagesButton.disabled = true;
 		clearError();
 		var messages = formatMessages(numbersAndNames.value, message.value);
 		sendMessages(messages);
@@ -98,11 +99,15 @@ function addUIListeners() {
 
 /**
  * hides the spinner and shows the relevant UI
- * @param  {bool} isHangoutsTab 	true if it should show the bulk message UI
+ * @param  {string} supportLevel 	'GV', 'HANGOUTS', or false
  */
-function showUI(isHangoutsTab) {
-	if (isHangoutsTab) {
+function showUI(supportLevel) {
+	if (supportLevel) {
 		document.getElementById('ui-wrapper').style.display = 'block';
+		if (supportLevel === 'HANGOUTS') {
+			var sendMessagesButton = document.getElementById('send-messages-button');
+			sendMessagesButton.innerText = 'Prepare Messages';
+		}
 	} else {
 		document.getElementById('wrong-page-message').style.display = 'block';
 		document.getElementById('popup-body').style['min-height'] = '275px';
@@ -113,10 +118,10 @@ function showUI(isHangoutsTab) {
 
 // configure popup button event listener
 document.addEventListener('DOMContentLoaded', () => {
-	currentlyOnSupportedTab(function(supported) {
-		console.log('supported', supported);
-		if (supported) {
-			showUI(true);
+	currentlyOnSupportedTab(function(supportLevel) {
+		console.log('support level', supportLevel);
+		if (supportLevel !== false) {
+			showUI(supportLevel);
 			addUIListeners();
 		} else {
 			showUI(false);

--- a/src/popup.js
+++ b/src/popup.js
@@ -3,12 +3,13 @@
  */
 function sendMessages(messages) {
 	if (!messages) {
-		return;
+		return false;
 	}
 
 	chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
 		chrome.tabs.sendMessage(tabs[0].id, {from: 'popup', type: 'SEND_MESSAGES', messages: messages});
 	});
+	return true;
 }
 
 /**
@@ -90,10 +91,11 @@ function addUIListeners() {
 	var message = document.getElementById('message');
 
 	sendMessagesButton.addEventListener('click', () => {
-		sendMessagesButton.disabled = true;
 		clearError();
 		var messages = formatMessages(numbersAndNames.value, message.value);
-		sendMessages(messages);
+		if (sendMessages(messages)) {
+			sendMessagesButton.disabled = true;
+		}
 	});
 }
 


### PR DESCRIPTION
This resolves #3. 

You can now send messages from voice.google.com. Since the Google Voice interface actually has a "Send" button (Hangouts does not), the extension can fully automate the send process for that domain. 

This also cleans up some error messaging and disables the send button after the first click.

